### PR TITLE
refactor(full library): update to angular2-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# 0.3.0-rc.0 (2016-05-07)
+
+This is the first release of Angular2-Toaster against the Angular2 Release Candidate. All Angular 2 
+NPM packages have been updated to use the appropriate `@angular/*` import syntax.  As a result, the 
+library is no longer backwards-compatible with Angular 2 Beta releases.  Please update to 
+`"@angular/*": "2.0.0-rc.1"` at minimum going forward.
+
+
+### Features
+* **BodyOutputType.Component:** BodyOutputType.Component (the ability to render components as the 
+body of the toast) has been updated to remove the soon to be deprecated `DynamicComponentLoader` in 
+favor of the `ComponentResolver`.  This eliminated a nasty but necessary manual timeout and 
+detectChanges pairing and resolved a long-standing TODO.
+* **Toast.Component:** Toast rendering has been moved to its own component.  This allows for 
+`BodyOutputType.Component` to properly load into the appropriate `TemplateRef` if multiple toasts 
+are rendering components concurrently.
+* **ToasterContainerComponent.Template:** The template has been updated to the new `*ngFor` syntax. 
+Closes [#14](https://github.com/Stabzs/Angular2-Toaster/issues/14).
+
+
+### Breaking Changes
+* **Angular2-rc compatibility**
+
+
+
 # 0.2.0-beta.0 (2016-04-11)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 largely based off of [AngularJS-Toaster](https://github.com/jirikavi/AngularJS-Toaster).
 
 [![Build Status](https://travis-ci.org/Stabzs/Angular2-Toaster.svg?branch=master)](https://travis-ci.org/Stabzs/Angular2-Toaster)
-[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&busted=1)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&bust=33)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
 
-### Current Version 0.2.0-beta.0
+### Current Version 0.3.0-rc.0
 
 ## Installation:
 
@@ -47,7 +47,7 @@ npm run test
 ## Getting Started with Default Configuration:
 
 ```typescript
-import {Component} from 'angular2/core';
+import {Component} from '@angular/core';
 import {ToasterContainerComponent, ToasterService} from 'angular2-toaster/angular2-toaster';
 
 @Component({
@@ -77,7 +77,7 @@ bootstrap(Root);
 ## Getting Started with Configuration Override:
 
 ```typescript
-import {Component} from 'angular2/core';
+import {Component} from '@angular/core';
 import {ToasterContainerComponent, ToasterService, ToasterConfig} from 'angular2-toaster/angular2-toaster';
 
 @Component({

--- a/angular2-toaster.d.ts
+++ b/angular2-toaster.d.ts
@@ -1,5 +1,6 @@
 export * from './lib/bodyOutputType';
 export * from './lib/toast';
+export * from './lib/toast.component';
 export * from './lib/toaster-config';
 export * from './lib/toaster-container.component';
 export * from './lib/toaster.service';

--- a/angular2-toaster.js
+++ b/angular2-toaster.js
@@ -1,5 +1,6 @@
 exports.BodyOutputType = require('./lib/bodyOutputType').BodyOutputType;
 exports.Toast = require('./lib/toast').Toast;
+exports.ToastComponent = require('./lib/toast.component').ToastComponent;
 exports.ToasterConfig = require('./lib/toaster-config').ToasterConfig;
 exports.ToasterContainerComponent = require('./lib/toaster-container.component').ToasterContainerComponent;
 exports.ToasterService = require('./lib/toaster.service').ToasterService;

--- a/demo/systemjs/index.html
+++ b/demo/systemjs/index.html
@@ -6,28 +6,15 @@
 
     <link rel="stylesheet" type="text/css" href="/node_modules/angular2-toaster/lib/toaster.css" />
 
-    <script src="/node_modules/angular2/bundles/angular2-polyfills.js"></script>
-    <script src="/node_modules/es6-shim/es6-shim.min.js"></script>
-    <script src="/node_modules/systemjs/dist/system.src.js"></script>
-    <script src="/node_modules/angular2/bundles/http.min.js"></script>
+     <script src="node_modules/es6-shim/es6-shim.min.js"></script>
 
+    <script src="node_modules/zone.js/dist/zone.js"></script>
+    <script src="node_modules/reflect-metadata/Reflect.js"></script>
+    <script src="node_modules/systemjs/dist/system.src.js"></script>
+
+    <script src="systemjs.config.js"></script>
     <script>
-        System.config({
-            defaultJSExtensions: true,
-            packages: {
-                "/angular2": {"defaultExtension": false}
-            },
-            map: {
-                'angular2-toaster': 'node_modules/angular2-toaster'
-            }
-        });
-    </script>
-
-    <script src="/node_modules/rxjs/bundles/Rx.js"></script>
-    <script src="/node_modules/angular2/bundles/angular2.js"></script>
-
-    <script>
-        System.import('build/app').catch(console.log.bind(console));
+      System.import('build/app').catch(function(err){ console.error(err);  });
     </script>
 </head>
 <body>

--- a/demo/systemjs/package.json
+++ b/demo/systemjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-toaster-systemjs-demo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -14,16 +14,21 @@
   "author": "Stabzs",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^1.8.9",
+    "typescript": "^1.8.10",
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.11",
-    "angular2-toaster": "0.2.0-beta.0",
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "rxjs": "5.0.0-beta.6",
+    "angular2-toaster": "0.3.0-rc.0",
     "es6-shim": "0.35.0",
     "http-server": "^0.8.5",
-    "reflect-metadata": "0.1.2",
-    "systemjs": "^0.19.9",
-    "zone.js": "0.6.11"
+    "reflect-metadata": "0.1.3",
+    "systemjs": "^0.19.27",
+    "zone.js": "0.6.12"
   }
 }

--- a/demo/systemjs/src/app.ts
+++ b/demo/systemjs/src/app.ts
@@ -1,5 +1,5 @@
-import {Component} from 'angular2/core';
-import {bootstrap} from 'angular2/platform/browser'
+import {Component} from '@angular/core';
+import {bootstrap} from '@angular/platform-browser-dynamic';
 import {BodyOutputType, Toast, ToasterConfig, ToasterService, ToasterContainerComponent} 
     from 'angular2-toaster/angular2-toaster';
 
@@ -10,6 +10,12 @@ import {BodyOutputType, Toast, ToasterConfig, ToasterService, ToasterContainerCo
 
 class TestComponent {}
 
+@Component({
+    selector: 'test-component2',
+    template: `<div>loaded via component 2</div>`
+})
+
+class TestComponent2 {}
 
 @Component({
     selector: 'root',
@@ -60,9 +66,17 @@ export class Root{
             showCloseButton: true
         };
         
+        var toast4: Toast = {
+            type: 'warning', 
+            title: 'Comp 2',
+            body: TestComponent2,
+            bodyOutputType: BodyOutputType.Component
+        }
+        
         console.log(this.toasterService.pop(toast));
         console.log(this.toasterService.pop(toast2));
         console.log(this.toasterService.pop(toast3));
+        console.log(this.toasterService.pop(toast4));
     }
     
     popToastFromArgs() {

--- a/demo/systemjs/src/tsconfig.json
+++ b/demo/systemjs/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,

--- a/demo/systemjs/systemjs.config.js
+++ b/demo/systemjs/systemjs.config.js
@@ -1,0 +1,43 @@
+(function(global) {
+
+  // map tells the System loader where to look for things
+  var map = {
+    'app':                          'app', // 'dist',
+    'rxjs':                         'node_modules/rxjs',
+    '@angular':                     'node_modules/@angular',
+    'angular2-toaster':             'node_modules/angular2-toaster',
+    //'reflect-metadata':             'node_modules/reflect-metadata',
+    //'zone':                         'node_modules/zone.js',
+  };
+
+  // packages tells the System loader how to load when no filename and/or no extension
+  var packages = {
+    'build':                        { main: 'app.js',  defaultExtension: 'js' },
+    'rxjs':                         { defaultExtension: 'js' },
+    'angular2-toaster':             { defaultExtension: 'js' }
+  };
+
+  var packageNames = [
+    '@angular/compiler',
+    '@angular/common',
+    '@angular/core',
+    '@angular/platform-browser',
+    '@angular/platform-browser-dynamic'
+  ];
+
+  // add package entries for angular packages in the form '@angular/common': { main: 'index.js', defaultExtension: 'js' }
+  packageNames.forEach(function(pkgName) {
+    packages[pkgName] = { main: 'index.js', defaultExtension: 'js' };
+  });
+
+  var config = {
+    map: map,
+    packages: packages
+  }
+
+  // filterSystemConfig - index.html's chance to modify config before we register it.
+  if (global.filterSystemConfig) { global.filterSystemConfig(config); }
+
+  System.config(config);
+
+})(this);

--- a/demo/webpack/package.json
+++ b/demo/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-toaster-systemjs-demo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -10,18 +10,20 @@
   "author": "Stabzs",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "1.8.9",
+    "typescript": "1.8.10",
     "webpack": "1.12.15",
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
     "es6-promise": "3.1.2",
     "es6-shim": "0.35.0",
-    "reflect-metadata": "0.1.2",
-    "systemjs": "^0.19.25",
-    "zone.js": "0.6.11",
+    "reflect-metadata": "0.1.3",
+    "systemjs": "^0.19.27",
+    "zone.js": "0.6.12",
     "ts-loader": "0.8.2",
-    "angular2": "2.0.0-beta.14",
-    "angular2-toaster": "0.2.0-beta.0"
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "angular2-toaster": "0.3.0-rc.0"
   }  
 }

--- a/demo/webpack/src/app.d.ts
+++ b/demo/webpack/src/app.d.ts
@@ -1,6 +1,8 @@
+import 'reflect-metadata';
 import { ToasterService } from 'angular2-toaster/angular2-toaster';
 export declare class App {
     private toasterService;
     constructor(toasterService: ToasterService);
     ngAfterViewInit(): void;
+    popToast(): void;
 }

--- a/demo/webpack/src/app.ts
+++ b/demo/webpack/src/app.ts
@@ -1,14 +1,17 @@
-import 'angular2/bundles/angular2-polyfills';
+declare var require;
+
+import 'reflect-metadata';
+require('zone.js/dist/zone');
+require('zone.js/dist/long-stack-trace-zone');
 import {ToasterContainerComponent, ToasterService, ToasterConfig} from 'angular2-toaster/angular2-toaster';
-import {Component} from 'angular2/core';
-import {FORM_PROVIDERS} from 'angular2/common';
-import {ROUTER_DIRECTIVES} from 'angular2/router';
-import {bootstrap} from 'angular2/platform/browser';
+import {Component} from '@angular/core';
+import {FORM_PROVIDERS} from '@angular/common';
+import {bootstrap} from '@angular/platform-browser-dynamic';
 
 @Component({
   selector: 'app',
   providers: [FORM_PROVIDERS, ToasterService],
-  directives: [ROUTER_DIRECTIVES, ToasterContainerComponent ],
+  directives: [ToasterContainerComponent],
   pipes: [],
   styles:[],
   template: `

--- a/demo/webpack/tsconfig.json
+++ b/demo/webpack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -1,53 +1,80 @@
 //Based on https://github.com/mgechev/angular2-seed/blob/master/test-main.js
+//Updated with excellent insight from https://github.com/antonybudianto/angular2-starter
 
 // Turn on full stack traces in errors to help debugging
-Error.stackTraceLimit=Infinity;
+Error.stackTraceLimit = Infinity;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 
 // Cancel Karma's synchronous start,
 // we will call `__karma__.start()` later, once all the specs are loaded.
-__karma__.loaded = function() {};
+__karma__.loaded = function () { };
 
-System.config({
-    baseURL: '/base/',
-    defaultJSExtensions: true,
-    paths: {
-        'angular2/*': 'node_modules/angular2/*.js',
-        'rxjs/*': 'node_modules/rxjs/*.js'
-    }
+var paths = {
+    'n:*': 'node_modules/*'
+};
+
+// map tells the System loader where to look for things
+var map = {
+    'lib': 'lib',
+    'src': 'src',
+    'rxjs': 'n:rxjs',
+    '@angular': 'n:@angular'
+};
+
+var packages = {
+    'src': { defaultExtension: 'ts', format: 'register' },
+    'lib': { defaultExtension: 'js' },
+    'rxjs': { defaultExtension: 'js' }
+};
+
+var packageNames = [
+    '@angular/common',
+    '@angular/compiler',
+    '@angular/core',
+    '@angular/platform-browser',
+    '@angular/platform-browser-dynamic',
+    '@angular/testing',
+];
+
+// add package entries for angular packages in the form '@angular/common': { main: 'index.js', defaultExtension: 'js' }
+packageNames.forEach(function (pkgName) {
+    packages[pkgName] = { main: 'index.js', defaultExtension: 'js' };
 });
 
+var config = {
+    baseURL: '/base/',
+    map: map,
+    packages: packages,
+    paths: paths
+};
+
+System.config(config);
+
+
 Promise.all([
-    System.import('angular2/src/platform/browser/browser_adapter'),
-    System.import('angular2/platform/testing/browser'),
-    System.import('angular2/testing')
+    System.import('@angular/platform-browser/src/browser/browser_adapter'),
+    System.import('@angular/platform-browser-dynamic/testing'),
+    System.import('@angular/core/testing'),
 ]).then(function (modules) {
     var browser_adapter = modules[0];
     var providers = modules[1];
     var testing = modules[2];
-    testing.setBaseTestProviders(providers.TEST_BROWSER_PLATFORM_PROVIDERS,
-        providers.TEST_BROWSER_APPLICATION_PROVIDERS);
+    testing.setBaseTestProviders(providers.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
+        providers.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
 
     browser_adapter.BrowserDomAdapter.makeCurrent();
-}).then(function() {
+}).then(function () {
     return Promise.all(
-        Object.keys(window.__karma__.files) // All files served by Karma.
+        Object.keys(window.__karma__.files)
             .filter(onlySpecFiles)
             .map(file2moduleName)
-            .map(function(path) {
-                return System.import(path).then(function(module) {
-                    if (module.hasOwnProperty('main')) {
-                        module.main();
-                    } else {
-                        throw new Error('Module ' + path + ' does not implement main() method.');
-                    }
-                });
-            }));
+            .map(importModules)
+    );
 })
-    .then(function() {
+    .then(function () {
         __karma__.start();
-    }, function(error) {
+    }, function (error) {
         console.error(error.stack || error);
         __karma__.start();
     });
@@ -61,4 +88,8 @@ function file2moduleName(filePath) {
     return filePath.replace(/\\/g, '/')
         .replace(/^\/base\//, '')
         .replace(/\.js/, '');
+}
+
+function importModules(path) {
+    return System.import(path);
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,29 +1,33 @@
 module.exports = function (config) {
-    config.set({
+    var dependencies = require('./package.json').dependencies;
+    var excludedDependencies = [
+        'systemjs', 'zone.js'
+    ];
 
+    var configuration = {
         basePath: '',
 
         frameworks: ['jasmine'],
 
         files: [
             'node_modules/zone.js/dist/zone.js',
-            'node_modules/zone.js/dist/zone-microtask.js',
             'node_modules/zone.js/dist/long-stack-trace-zone.js',
             'node_modules/zone.js/dist/jasmine-patch.js',
             'node_modules/es6-promise/dist/es6-promise.js',
             'node_modules/es6-shim/es6-shim.js',
-            'node_modules/systemjs/dist/system.src.js',
+            'node_modules/systemjs/dist/system-polyfills.js',
             'node_modules/reflect-metadata/Reflect.js',
+            'node_modules/zone.js/dist/async-test.js',
+            'node_modules/zone.js/dist/fake-async-test.js',
+            'node_modules/systemjs/dist/system.src.js',
 
-            { pattern: 'node_modules/angular2/**/*.js', included: false, watched: false },
-            { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
-            { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: false, watched: false },
+            'karma-test-shim.js',
 
-            { pattern: 'lib/**/*.js', included: false, watched: true },
-            
-            'karma-test-shim.js'
+            { pattern: 'lib/**/*.js', included: false },
+            { pattern: 'lib/**/*.js.map', included: false, watched: false },
+            { pattern: 'src/**/*.ts', included: false, watched: false }
         ],
-        
+
         reporters: ['progress'],
         port: 9876,
         colors: true,
@@ -31,5 +35,17 @@ module.exports = function (config) {
         autoWatch: true,
         browsers: ['Chrome'],
         singleRun: false
-    })
+    };
+
+    Object.keys(dependencies).forEach(function (key) {
+        if (excludedDependencies.indexOf(key) >= 0) { return; }
+
+        configuration.files.push({
+            pattern: 'node_modules/' + key + '/**/*.js',
+            included: false,
+            watched: false
+        });
+    });
+
+    config.set(configuration);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-toaster",
-  "version": "0.2.0-beta.0",
+  "version": "0.3.0-rc.0",
   "description": "An Angular 2 Toaster Notification library based on AngularJS-Toaster",
   "main": "angular2-toaster.ts",
   "scripts": {
@@ -32,8 +32,12 @@
   },
   "typings": "./angular2-toaster.d.ts",
   "dependencies": {
-    "angular2": "^2.0.0-beta.14",
-    "rxjs": "5.0.0-beta.2"
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "rxjs": "5.0.0-beta.6"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",
@@ -43,13 +47,13 @@
     "http-server": "^0.9.0",
     "jasmine-core": "2.4.1",
     "karma": "^0.13.22",
-    "karma-chrome-launcher": "^0.2.3",
+    "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^0.5.5",
     "karma-jasmine": "^0.3.8",
-    "reflect-metadata": "0.1.2",
-    "remap-istanbul": "^0.5.1",
-    "systemjs": "^0.19.25",
-    "typescript": "1.8.9",
-    "zone.js": "0.6.11"
+    "reflect-metadata": "0.1.3",
+    "remap-istanbul": "^0.6.3",
+    "systemjs": "^0.19.27",
+    "typescript": "1.8.10",
+    "zone.js": "0.6.12"
   }
 }

--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -1,0 +1,45 @@
+import {Component, Input, ViewChild, ComponentResolver, ViewContainerRef, EventEmitter}
+from '@angular/core';
+
+import {Toast, ClickHandler} from './toast';
+import {BodyOutputType} from './bodyOutputType';
+
+@Component({
+    selector: '[toastComp]',
+    template: `
+        <div *ngIf="toast.showCloseButton" (click)="click(toast)" [innerHTML]="toast.closeHtml"></div>
+        <i class="toaster-icon" [ngClass]="iconClass"></i>
+        <div [ngClass]="toast.toasterConfig.titleClass">{{toast.title}}</div>
+        <div [ngClass]="toast.toasterConfig.messageClass" [ngSwitch]="toast.bodyOutputType">
+            <div *ngSwitchWhen="bodyOutputType.Component" #componentBody></div> 
+            <div *ngSwitchWhen="bodyOutputType.TrustedHtml" [innerHTML]="toast.html"></div>
+            <div *ngSwitchWhen="bodyOutputType.Default">{{toast.body}}</div>
+        </div>`,
+    outputs: ['clickEvent']
+})
+
+export class ToastComponent {
+
+    @Input() toast: Toast;
+    @Input() iconClass: string;
+    @ViewChild('componentBody', { read: ViewContainerRef }) componentBody: ViewContainerRef;
+
+    private bodyOutputType = BodyOutputType;
+    public clickEvent = new EventEmitter();
+
+    constructor(private resolver: ComponentResolver) { }
+
+    ngOnInit() {
+        if (this.toast.bodyOutputType === this.bodyOutputType.Component) {
+            this.resolver.resolveComponent(this.toast.body).then(factory => {
+                this.componentBody.createComponent(factory, 0, this.componentBody.injector);
+            });
+        }
+    }
+    
+    click(toast: Toast) {
+        this.clickEvent.emit({
+            value : { toast: toast, isCloseButton: true}
+        });
+    }
+}

--- a/src/toaster-container.component.spec.ts
+++ b/src/toaster-container.component.spec.ts
@@ -1,9 +1,11 @@
-import {Component, Input, DynamicComponentLoader, ChangeDetectorRef, provide} from 'angular2/core';
+import {Component, Input, ChangeDetectorRef, provide, ComponentResolver} 
+    from '@angular/core';
 
 import {
-    describe, expect, it, inject, injectAsync, beforeEach, beforeEachProviders,
-    TestComponentBuilder, ComponentFixture
-} from 'angular2/testing';
+    describe, expect, it, inject, injectAsync, beforeEach, beforeEachProviders
+} from '@angular/core/testing';
+
+import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 
 import {Toast} from './toast';
 import {ToasterService} from './toaster.service';
@@ -37,696 +39,705 @@ export class TestComponent {
 class TestDynamicComponent { }
 
 
-export function main() {
-    describe('ToasterContainerComponent with sync ToasterService', () => {
-        var toasterService: ToasterService,
-            toasterContainer: ToasterContainerComponent;
+describe('ToasterContainerComponent with sync ToasterService', () => {
+    var toasterService: ToasterService,
+        toasterContainer: ToasterContainerComponent;
 
-        beforeEachProviders(() => [
-            ToasterContainerComponent,
-            ToasterService,
-            DynamicComponentLoader,
-            ChangeDetectorRef
-        ]);
+    beforeEachProviders(() => [
+        ToasterContainerComponent,
+        ToasterService,
+        ChangeDetectorRef,
+        ComponentResolver
+    ]);
 
-        beforeEach(inject([DynamicComponentLoader, ChangeDetectorRef], (dcl, changeDetector) => {
-            toasterService = new ToasterService();
-            toasterContainer = new ToasterContainerComponent(toasterService, dcl, changeDetector);
-        }));
+    beforeEach(inject([ChangeDetectorRef, ComponentResolver], (changeDetector, compRes) => {
+        toasterService = new ToasterService();
+        toasterContainer = new ToasterContainerComponent(toasterService);
+    }));
 
 
-        it('should pop toast synchronously', () => {
-            toasterContainer.ngOnInit();
-            toasterService.pop('success', 'test', 'test');
+    it('should pop toast synchronously', () => {
+        toasterContainer.ngOnInit();
+        toasterService.pop('success', 'test', 'test');
 
-            expect(toasterContainer.toasts.length).toBe(1);
-        });
+        expect(toasterContainer.toasts.length).toBe(1);
+    });
 
-        it('should pop toast asynchronously', () => {
-            toasterContainer.ngOnInit();
+    it('should pop toast asynchronously', () => {
+        toasterContainer.ngOnInit();
 
-            toasterService.popAsync('success', 'test', 'test')
-                .subscribe(toast => {
-                    expect(toast).toBeDefined();
-                    expect(toast.type).toBe('success');
-                    expect(toasterContainer.toasts.length).toBe(1);
-                    expect(toast.toastId).toBe(toasterContainer.toasts[0].toastId);
-                });
-        });
+        toasterService.popAsync('success', 'test', 'test')
+            .subscribe(toast => {
+                expect(toast).toBeDefined();
+                expect(toast.type).toBe('success');
+                expect(toasterContainer.toasts.length).toBe(1);
+                expect(toast.toastId).toBe(toasterContainer.toasts[0].toastId);
+            });
+    });
 
-        it('should pop toast asynchronously multiple times', () => {
-            toasterContainer.ngOnInit();
+    it('should pop toast asynchronously multiple times', () => {
+        toasterContainer.ngOnInit();
 
-            toasterService.popAsync('success', 'test', 'test');
-            toasterService.popAsync('success', 'test', 'test');
-            toasterService.popAsync('success', 'test', 'test')
-                .subscribe(toast => {
-                    expect(toast).toBeDefined();
-                    expect(toast.type).toBe('success');
+        toasterService.popAsync('success', 'test', 'test');
+        toasterService.popAsync('success', 'test', 'test');
+        toasterService.popAsync('success', 'test', 'test')
+            .subscribe(toast => {
+                expect(toast).toBeDefined();
+                expect(toast.type).toBe('success');
 
-                    var locatedToast;
-                    for (var i = 0; i < toasterContainer.toasts.length; i++) {
-                        if (toasterContainer.toasts[i].toastId === toast.toastId) {
-                            locatedToast = toasterContainer.toasts[i];
-                            break;
-                        }
+                var locatedToast;
+                for (var i = 0; i < toasterContainer.toasts.length; i++) {
+                    if (toasterContainer.toasts[i].toastId === toast.toastId) {
+                        locatedToast = toasterContainer.toasts[i];
+                        break;
                     }
-
-                    expect(locatedToast).toBeDefined();
-                });
-        });
-
-        it('should retrieve toast instance from pop observer', () => {
-            toasterContainer.ngOnInit();
-            var toast: Toast = {
-                type: 'success',
-                title: 'observer toast'
-            };
-
-            expect(toasterContainer.toasts.length).toBe(0);
-
-            var toast = toasterService.pop(toast);
-
-            expect(toast).toBeDefined();
-            expect(toast.type).toBe(toast.type);
-            expect(toast.title).toBe(toast.title);
-            expect(toast.toastId).toBe(toasterContainer.toasts[0].toastId);
-        });
-
-        it('should clear toast synchronously', () => {
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterService.clear();
-            expect(toasterContainer.toasts.length).toBe(0);
-        });
-
-        it('should throw exception if toast is popped without any subscribers being registered', () => {
-            let hasError: boolean = false;
-
-            try {
-                toasterService.pop('success', 'test', 'test');
-            }
-            catch (e) {
-                hasError = true;
-                expect(e.message).toBe('No Toaster Containers have been initialized to receive toasts.');
-            }
-
-            expect(toasterContainer.toasts.length).toBe(0);
-            expect(hasError).toBe(true);
-        });
-
-        it('should remove subscribers when ngOnDestroy is called', () => {
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterContainer.ngOnDestroy();
-
-            toasterService.pop('success', 'test 2', 'test 2');
-            toasterService.clear();
-            expect(toasterContainer.toasts.length).toBe(1);
-        });
-
-        it('stopTimer should clear timer if mouseOverTimerStop is true', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 100 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeDefined();
-
-            toasterContainer.stopTimer(toast);
-            expect(toast.timeoutId).toBeNull();
-        });
-
-        it('stopTimer should not clear timer if mouseOverTimerStop is false', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ timeout: 100 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeDefined();
-
-            toasterContainer.stopTimer(toast);
-            expect(toast.timeoutId).toBeDefined();
-        });
-
-        it('stopTimer should not clear timer if mouseOverTimerStop is true and timeout is 0', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 0 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
-            expect(toast).toBeDefined();
-            expect(toast.timeout).toBeUndefined();
-            expect(toast.timeoutId).toBeUndefined();
-
-            toasterContainer.stopTimer(toast);
-            expect(toast.timeoutId).toBeUndefined();
-        });
-
-        it('restartTimer should restart timer if mouseOverTimerStop is true', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 100 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeDefined();
-
-            toasterContainer.restartTimer(toast);
-            expect(toast.timeoutId).toBeDefined();
-        });
-
-        it('restartTimer should not restart timer if mouseOverTimerStop is true and timeoutId is undefined', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 0 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeUndefined();
-
-            toasterContainer.restartTimer(toast);
-            expect(toast.timeoutId).toBeUndefined();
-        });
-
-        it('restartTimer should not restart timer if mouseOverTimerStop is false', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ timeout: 1 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeDefined();
-
-            toasterContainer.restartTimer(toast);
-
-            setTimeout(() => {
-                expect(toast.timeoutId).toBeNull();
-            }, 2)
-        });
-
-        it('restartTimer should remove toast if mouseOverTimerStop is false and timeoutId is null', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ timeout: 0 });
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('success', 'test', 'test');
-            var toast = toasterContainer.toasts[0];
-
-            expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
-            expect(toast).toBeDefined();
-            expect(toast.timeoutId).toBeUndefined();
-
-            toast.timeoutId = null;
-            toasterContainer.restartTimer(toast);
-            expect(toasterContainer.toasts.length).toBe(0);
-        });
-
-        it('addToast should not add toast if toasterContainerId is provided and it does not match', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 2 })
-            var toast: Toast = { type: 'success', toastContainerId: 1 };
-            toasterContainer.ngOnInit();
-
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(0);
-        });
-
-        it('addToast should use defaultTypeClass if type is empty string', () => {
-            toasterContainer.ngOnInit();
-
-            toasterService.pop('', '', '');
-
-            expect(toasterContainer.toasterconfig.defaultTypeClass).toBe('toast-info');
-            expect(toasterContainer.toasts.length).toBe(1);
-            expect(toasterContainer.toasts[0].type).toBe('toast-info');
-        });
-
-        it('addToast should not add toast if preventDuplicates and the same toastId exists', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ preventDuplicates: true });
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info' };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-            toasterService.pop(toast);
-            expect(toasterContainer.toasts.length).toBe(1);
-        });
-
-        it('addToast should not add toast if preventDuplicates and toastId does not exist and the same body exists', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ preventDuplicates: true });
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info', body: 'test' };
-            var toast2: Toast = { type: 'info', body: 'test2' };
-            var toast3: Toast = { type: 'info', body: 'test2' };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-            toasterService.pop(toast2);
-            expect(toasterContainer.toasts.length).toBe(2);
-            toasterService.pop(toast3);
-            expect(toasterContainer.toasts.length).toBe(2);
-        });
-
-        it('addToast uses toast.showCloseButton if defined', () => {
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info', showCloseButton: true };
-
-            toasterService.pop(toast);
-            expect(toasterContainer.toasts[0].showCloseButton).toBe(true);
-        });
-
-        it('addToast uses toasterconfig.showCloseButton object if defined and toast.showCloseButton is undefined', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ showCloseButton: { 'info': true } });
-
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info' };
-            var toast2: Toast = { type: 'success' };
-
-            toasterService.pop(toast);
-            toasterService.pop(toast2);
-
-            var infoToast = toasterContainer.toasts.filter(t => t.type === 'info')[0];
-            var successToast = toasterContainer.toasts.filter(t => t.type === 'success')[0];
-
-            expect(infoToast.showCloseButton).toBe(true);
-            expect(successToast.showCloseButton).toBeUndefined();
-        });
-
-        it('addToast uses toast.showCloseButton if defined', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ showCloseButton: '' });
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info' };
-
-            toasterService.pop(toast);
-            expect(toasterContainer.toasts[0].showCloseButton).toBeUndefined;
-        });
-
-        it('addToast removes toast from bottom if toasterconfig.newestOnTop and limit exceeded', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ limit: 2 });
-            toasterContainer.ngOnInit();
-
-            expect(toasterContainer.toasterconfig.newestOnTop).toBe(true);
-            expect(toasterContainer.toasterconfig.limit).toBe(2);
-
-            var toast1: Toast = { type: 'info', title: '1', body: '1' };
-            var toast2: Toast = { type: 'info', title: '2', body: '2' };
-            var toast3: Toast = { type: 'info', title: '3', body: '3' };
-            var toast4: Toast = { type: 'info', title: '4', body: '4' };
-
-            toasterService.pop(toast1);
-            toasterService.pop(toast2);
-            toasterService.pop(toast3);
-            toasterService.pop(toast4);
-            expect(toasterContainer.toasts.length).toBe(2);
-            expect(toasterContainer.toasts[0].title).toBe('4');
-            expect(toasterContainer.toasts[0]).toBe(toast4);
-        });
-
-        it('addToast removes toast from top if !toasterconfig.newestOnTop and limit exceeded', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ newestOnTop: false, limit: 2 });
-            toasterContainer.ngOnInit();
-
-            expect(toasterContainer.toasterconfig.newestOnTop).toBe(false);
-            expect(toasterContainer.toasterconfig.limit).toBe(2);
-
-            var toast1: Toast = { type: 'info', title: '1', body: '1' };
-            var toast2: Toast = { type: 'info', title: '2', body: '2' };
-            var toast3: Toast = { type: 'info', title: '3', body: '3' };
-            var toast4: Toast = { type: 'info', title: '4', body: '4' };
-
-            toasterService.pop(toast1);
-            toasterService.pop(toast2);
-            toasterService.pop(toast3);
-            toasterService.pop(toast4);
-            expect(toasterContainer.toasts.length).toBe(2);
-            expect(toasterContainer.toasts[0].title).toBe('3');
-            expect(toasterContainer.toasts[0]).toBe(toast3);
-        });
-
-        it('addToast calls onShowCallback if it exists', () => {
-            toasterContainer.ngOnInit();
-
-            var toast: Toast = { type: 'info', title: 'default', onShowCallback: (toaster) => toaster.title = 'updated' };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts[0].title).toBe('updated');
-        });
-
-        it('addToast registers timeout callback if timeout is greater than 0', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ timeout: 1 });
-            toasterContainer.ngOnInit();
-            var toast = toasterService.pop('success');
-            
-            expect(toast.timeoutId).toBeDefined();
-            expect(toasterContainer.toasts.length).toBe(1);
-            
-            setTimeout(() => {
-                expect(toasterContainer.toasts.length).toBe(0);
-                expect(toast.timeoutId).toBeNull(); 
-            }, 2);
-        });
-
-        it('addToast uses toasterconfig.timeout object if defined and type exists', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ timeout: { 'info': 10 } });
-
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info' };
-            var toast2: Toast = { type: 'success' };
-
-            toasterService.pop(toast);
-            toasterService.pop(toast2);
-
-            var infoToast = toasterContainer.toasts.filter(t => t.type === 'info')[0];
-            var successToast = toasterContainer.toasts.filter(t => t.type === 'success')[0];
-
-            expect(infoToast.timeoutId).toBeDefined();
-            expect(successToast.timeoutId).toBeUndefined();
-        });
-
-        it('removeToast will not remove the toast if it is not found in the toasters array', () => {
-            toasterContainer.ngOnInit();
-            var toast: Toast = { type: 'info' };
-            var toast2: Toast = { type: 'success' };
-
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterService.clear('faketoastid');
-            expect(toasterContainer.toasts.length).toBe(1);
-        });
-
-        it('removeToast calls onHideCallback if it exists', () => {
-            toasterContainer.ngOnInit();
-
-            var status = 'not updated';
-            var toast: Toast = { type: 'info', title: 'default', onHideCallback: (toast) => status = 'updated' };
-            toasterService.pop(toast);
-            toasterService.clear(toast.toastId);
-
-            expect(status).toBe('updated');
-        });
-
-        it('clearToasts will clear toasts from all containers if toastContainerId is undefined', () => {
-            toasterContainer.ngOnInit();
-
-            var toast: Toast = { type: 'info' };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterService.clear(null, undefined);
-            expect(toasterContainer.toasts.length).toBe(0);
-        });
-
-        it('clearToasts will clear toasts from specified container if toastContainerId is number', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
-            toasterContainer.ngOnInit();
-
-            var toast: Toast = { type: 'info', toastContainerId: 1 };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterService.clear(null, 1);
-            expect(toasterContainer.toasts.length).toBe(0);
-        });
-
-        it('clearToasts will not clear toasts from specified container if toastContainerId does not match', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
-            toasterContainer.ngOnInit();
-
-            var toast: Toast = { type: 'info', toastContainerId: 1 };
-            toasterService.pop(toast);
-
-            expect(toasterContainer.toasts.length).toBe(1);
-
-            toasterService.clear(null, 2);
-            expect(toasterContainer.toasts.length).toBe(1);
-        });
-
-        it('createGuid should create unique Guids', () => {
-            toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
-            toasterContainer.ngOnInit();
-            
-            var toastIds = [];
-
-            for (var i = 0; i < 10000; i++) {
-                var toast = toasterService.pop('success', 'toast');
-                toastIds.push(toast.toastId);
-                toasterService.clear();
-            }
-
-            var valuesSoFar = Object.create(null);
-            var dupFound = false;
-            for (var i = 0; i < toastIds.length; ++i) {
-                var value = toastIds[i];
-                if (value in valuesSoFar) {
-                    dupFound = true;
-                    break;
                 }
-                valuesSoFar[value] = true;
-            }
-            
-            expect(dupFound).toBe(false);
-            
-            toastIds = null;
-            valuesSoFar = null;
-        });
+
+                expect(locatedToast).toBeDefined();
+            });
     });
 
+    it('should retrieve toast instance from pop observer', () => {
+        toasterContainer.ngOnInit();
+        var toast: Toast = {
+            type: 'success',
+            title: 'observer toast'
+        };
 
-    describe('ToasterContainerComponent when included as a component', () => {
-        var dynamicComponentLoader: DynamicComponentLoader,
-            changeDetectorRef: ChangeDetectorRef,
-            testComponentBuilder: TestComponentBuilder;
+        expect(toasterContainer.toasts.length).toBe(0);
 
-        let fixture;
+        var toast = toasterService.pop(toast);
 
-        beforeEach(injectAsync([TestComponentBuilder], tcb => {
-            return tcb
-                .createAsync(TestComponent)
-                .then((f: ComponentFixture) => fixture = f)
-                .catch(e => expect(e).toBeUndefined());
-        }));
-
-        it('should use the bound toasterconfig object if provided', () => {
-            fixture.detectChanges();
-
-            expect(fixture.componentInstance).toBeDefined();
-
-            var container = fixture.debugElement.children[0].componentInstance;
-
-            expect(container).toBeDefined();
-            expect(container.toasterconfig).toBeDefined();
-            expect(container.toasterconfig.showCloseButton).toBe(true);
-            expect(container.toasterconfig.tapToDismiss).toBe(false);
-            expect(container.toasterconfig.timeout).toBe(0);
-        });
-
-        it('should invoke the click event when a toast is clicked but not remove toast if !tapToDismiss', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-            expect(container.toasterconfig.tapToDismiss).toBe(false);
-
-            fixture.componentInstance.toasterService.pop('success', 'test', 'test');
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toast = fixture.nativeElement.querySelector('div.toast');
-
-            toast.click();
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-        });
-
-        it('should invoke the click event when a toast is clicked and remove toast if tapToDismiss', () => {
-            fixture.componentInstance.toasterconfig.tapToDismiss = true;
-            fixture.detectChanges();
-            expect(fixture.componentInstance).toBeDefined();
-            var container = fixture.debugElement.children[0].componentInstance;
-
-            expect(container.toasterconfig.tapToDismiss).toBe(true);
-
-            fixture.componentInstance.toasterService.pop('success', 'test', 'test');
-
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toast = fixture.nativeElement.querySelector('div.toast');
-
-            toast.click();
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(0);
-        });
-
-        it('should invoke the click event when the close button is clicked even if !tapToDismiss', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-
-            expect(container.toasterconfig.tapToDismiss).toBe(false);
-
-            fixture.componentInstance.toasterService.pop('success', 'test', 'test');
-
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
-
-            toastButton.click();
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(0);
-        });
-
-        it('should remove toast if clickHandler evaluates to true', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-            var toast: Toast = {
-                type: 'success', clickHandler: (toast, isCloseButton) => { return true; }
-            };
-
-            fixture.componentInstance.toasterService.pop(toast);
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
-
-            toastButton.click();
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(0);
-        });
-
-        it('should not remove toast if clickHandler evaluates to false', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-            var toast: Toast = {
-                type: 'success', clickHandler: (toast, isCloseButton) => { return false; }
-            };
-
-            fixture.componentInstance.toasterService.pop(toast);
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
-
-            toastButton.click();
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-        });
-
-        it('should log error if clickHandler is not a function and not remove toast', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-            var toast = { type: 'success', clickHandler: {} };
-
-            fixture.componentInstance.toasterService.pop(toast);
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
-            var x = toastButton.click()
-
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-        });
-
-        it('addToast should render component if it exists', () => {
-            fixture.detectChanges();
-            var container = fixture.debugElement.children[0].componentInstance;
-            var toast: Toast = {
-                type: 'success',
-                title: 'Yay',
-                body: TestDynamicComponent,
-                bodyOutputType: BodyOutputType.Component
-            }
-
-            fixture.componentInstance.toasterService.pop(toast);
-            fixture.detectChanges();
-            expect(container.toasts.length).toBe(1);
-
-            setTimeout(() => {
-                var renderedToast = fixture.nativeElement.querySelector('#componentBody');
-                expect(renderedToast.innerHTML).toBe('<div>loaded via component</div>');
-            }, 1);
-        });
+        expect(toast).toBeDefined();
+        expect(toast.type).toBe(toast.type);
+        expect(toast.title).toBe(toast.title);
+        expect(toast.toastId).toBe(toasterContainer.toasts[0].toastId);
     });
 
-    describe('Multiple ToasterContainerComponent components', () => {
-        var dynamicComponentLoader: DynamicComponentLoader,
-            changeDetectorRef: ChangeDetectorRef,
-            testComponentBuilder: TestComponentBuilder;
+    it('should clear toast synchronously', () => {
+        toasterContainer.ngOnInit();
 
-        let fixture;
+        toasterService.pop('success', 'test', 'test');
+        expect(toasterContainer.toasts.length).toBe(1);
 
-        beforeEach(injectAsync([TestComponentBuilder], tcb => {
-            return tcb
-                .overrideTemplate(TestComponent,
-                `<toaster-container [toasterconfig]="toasterconfig"></toaster-container>
+        toasterService.clear();
+        expect(toasterContainer.toasts.length).toBe(0);
+    });
+
+    it('should throw exception if toast is popped without any subscribers being registered', () => {
+        let hasError: boolean = false;
+
+        try {
+            toasterService.pop('success', 'test', 'test');
+        }
+        catch (e) {
+            hasError = true;
+            expect(e.message).toBe('No Toaster Containers have been initialized to receive toasts.');
+        }
+
+        expect(toasterContainer.toasts.length).toBe(0);
+        expect(hasError).toBe(true);
+    });
+
+    it('should remove subscribers when ngOnDestroy is called', () => {
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        toasterContainer.ngOnDestroy();
+
+        toasterService.pop('success', 'test 2', 'test 2');
+        toasterService.clear();
+        expect(toasterContainer.toasts.length).toBe(1);
+    });
+
+    it('stopTimer should clear timer if mouseOverTimerStop is true', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 100 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeDefined();
+
+        toasterContainer.stopTimer(toast);
+        expect(toast.timeoutId).toBeNull();
+    });
+
+    it('stopTimer should not clear timer if mouseOverTimerStop is false', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ timeout: 100 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeDefined();
+
+        toasterContainer.stopTimer(toast);
+        expect(toast.timeoutId).toBeDefined();
+    });
+
+    it('stopTimer should not clear timer if mouseOverTimerStop is true and timeout is 0', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 0 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
+        expect(toast).toBeDefined();
+        expect(toast.timeout).toBeUndefined();
+        expect(toast.timeoutId).toBeUndefined();
+
+        toasterContainer.stopTimer(toast);
+        expect(toast.timeoutId).toBeUndefined();
+    });
+
+    it('restartTimer should restart timer if mouseOverTimerStop is true', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 100 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeDefined();
+
+        toasterContainer.restartTimer(toast);
+        expect(toast.timeoutId).toBeDefined();
+    });
+
+    it('restartTimer should not restart timer if mouseOverTimerStop is true and timeoutId is undefined', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ mouseoverTimerStop: true, timeout: 0 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(true);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeUndefined();
+
+        toasterContainer.restartTimer(toast);
+        expect(toast.timeoutId).toBeUndefined();
+    });
+
+    it('restartTimer should not restart timer if mouseOverTimerStop is false', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ timeout: 1 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeDefined();
+
+        toasterContainer.restartTimer(toast);
+
+        setTimeout(() => {
+            expect(toast.timeoutId).toBeNull();
+        }, 2)
+    });
+
+    it('restartTimer should remove toast if mouseOverTimerStop is false and timeoutId is null', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ timeout: 0 });
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('success', 'test', 'test');
+        var toast = toasterContainer.toasts[0];
+
+        expect(toasterContainer.toasterconfig.mouseoverTimerStop).toBe(false);
+        expect(toast).toBeDefined();
+        expect(toast.timeoutId).toBeUndefined();
+
+        toast.timeoutId = null;
+        toasterContainer.restartTimer(toast);
+        expect(toasterContainer.toasts.length).toBe(0);
+    });
+
+    it('addToast should not add toast if toasterContainerId is provided and it does not match', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 2 })
+        var toast: Toast = { type: 'success', toastContainerId: 1 };
+        toasterContainer.ngOnInit();
+
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(0);
+    });
+
+    it('addToast should use defaultTypeClass if type is empty string', () => {
+        toasterContainer.ngOnInit();
+
+        toasterService.pop('', '', '');
+
+        expect(toasterContainer.toasterconfig.defaultTypeClass).toBe('toast-info');
+        expect(toasterContainer.toasts.length).toBe(1);
+        expect(toasterContainer.toasts[0].type).toBe('toast-info');
+    });
+
+    it('addToast should not add toast if preventDuplicates and the same toastId exists', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ preventDuplicates: true });
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info' };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+        toasterService.pop(toast);
+        expect(toasterContainer.toasts.length).toBe(1);
+    });
+
+    it('addToast should not add toast if preventDuplicates and toastId does not exist and the same body exists', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ preventDuplicates: true });
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info', body: 'test' };
+        var toast2: Toast = { type: 'info', body: 'test2' };
+        var toast3: Toast = { type: 'info', body: 'test2' };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+        toasterService.pop(toast2);
+        expect(toasterContainer.toasts.length).toBe(2);
+        toasterService.pop(toast3);
+        expect(toasterContainer.toasts.length).toBe(2);
+    });
+
+    it('addToast uses toast.showCloseButton if defined', () => {
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info', showCloseButton: true };
+
+        toasterService.pop(toast);
+        expect(toasterContainer.toasts[0].showCloseButton).toBe(true);
+    });
+
+    it('addToast uses toasterconfig.showCloseButton object if defined and toast.showCloseButton is undefined', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ showCloseButton: { 'info': true } });
+
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info' };
+        var toast2: Toast = { type: 'success' };
+
+        toasterService.pop(toast);
+        toasterService.pop(toast2);
+
+        var infoToast = toasterContainer.toasts.filter(t => t.type === 'info')[0];
+        var successToast = toasterContainer.toasts.filter(t => t.type === 'success')[0];
+
+        expect(infoToast.showCloseButton).toBe(true);
+        expect(successToast.showCloseButton).toBeUndefined();
+    });
+
+    it('addToast uses toast.showCloseButton if defined', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ showCloseButton: '' });
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info' };
+
+        toasterService.pop(toast);
+        expect(toasterContainer.toasts[0].showCloseButton).toBeUndefined;
+    });
+
+    it('addToast removes toast from bottom if toasterconfig.newestOnTop and limit exceeded', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ limit: 2 });
+        toasterContainer.ngOnInit();
+
+        expect(toasterContainer.toasterconfig.newestOnTop).toBe(true);
+        expect(toasterContainer.toasterconfig.limit).toBe(2);
+
+        var toast1: Toast = { type: 'info', title: '1', body: '1' };
+        var toast2: Toast = { type: 'info', title: '2', body: '2' };
+        var toast3: Toast = { type: 'info', title: '3', body: '3' };
+        var toast4: Toast = { type: 'info', title: '4', body: '4' };
+
+        toasterService.pop(toast1);
+        toasterService.pop(toast2);
+        toasterService.pop(toast3);
+        toasterService.pop(toast4);
+        expect(toasterContainer.toasts.length).toBe(2);
+        expect(toasterContainer.toasts[0].title).toBe('4');
+        expect(toasterContainer.toasts[0]).toBe(toast4);
+    });
+
+    it('addToast removes toast from top if !toasterconfig.newestOnTop and limit exceeded', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ newestOnTop: false, limit: 2 });
+        toasterContainer.ngOnInit();
+
+        expect(toasterContainer.toasterconfig.newestOnTop).toBe(false);
+        expect(toasterContainer.toasterconfig.limit).toBe(2);
+
+        var toast1: Toast = { type: 'info', title: '1', body: '1' };
+        var toast2: Toast = { type: 'info', title: '2', body: '2' };
+        var toast3: Toast = { type: 'info', title: '3', body: '3' };
+        var toast4: Toast = { type: 'info', title: '4', body: '4' };
+
+        toasterService.pop(toast1);
+        toasterService.pop(toast2);
+        toasterService.pop(toast3);
+        toasterService.pop(toast4);
+        expect(toasterContainer.toasts.length).toBe(2);
+        expect(toasterContainer.toasts[0].title).toBe('3');
+        expect(toasterContainer.toasts[0]).toBe(toast3);
+    });
+
+    it('addToast calls onShowCallback if it exists', () => {
+        toasterContainer.ngOnInit();
+
+        var toast: Toast = { type: 'info', title: 'default', onShowCallback: (toaster) => toaster.title = 'updated' };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts[0].title).toBe('updated');
+    });
+
+    it('addToast registers timeout callback if timeout is greater than 0', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ timeout: 1 });
+        toasterContainer.ngOnInit();
+        var toast = toasterService.pop('success');
+
+        expect(toast.timeoutId).toBeDefined();
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        setTimeout(() => {
+            expect(toasterContainer.toasts.length).toBe(0);
+            expect(toast.timeoutId).toBeNull();
+        }, 2);
+    });
+
+    it('addToast uses toasterconfig.timeout object if defined and type exists', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ timeout: { 'info': 10 } });
+
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info' };
+        var toast2: Toast = { type: 'success' };
+
+        toasterService.pop(toast);
+        toasterService.pop(toast2);
+
+        var infoToast = toasterContainer.toasts.filter(t => t.type === 'info')[0];
+        var successToast = toasterContainer.toasts.filter(t => t.type === 'success')[0];
+
+        expect(infoToast.timeoutId).toBeDefined();
+        expect(successToast.timeoutId).toBeUndefined();
+    });
+
+    it('removeToast will not remove the toast if it is not found in the toasters array', () => {
+        toasterContainer.ngOnInit();
+        var toast: Toast = { type: 'info' };
+        var toast2: Toast = { type: 'success' };
+
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        toasterService.clear('faketoastid');
+        expect(toasterContainer.toasts.length).toBe(1);
+    });
+
+    it('removeToast calls onHideCallback if it exists', () => {
+        toasterContainer.ngOnInit();
+
+        var status = 'not updated';
+        var toast: Toast = { type: 'info', title: 'default', onHideCallback: (toast) => status = 'updated' };
+        toasterService.pop(toast);
+        toasterService.clear(toast.toastId);
+
+        expect(status).toBe('updated');
+    });
+
+    it('clearToasts will clear toasts from all containers if toastContainerId is undefined', () => {
+        toasterContainer.ngOnInit();
+
+        var toast: Toast = { type: 'info' };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        toasterService.clear(null, undefined);
+        expect(toasterContainer.toasts.length).toBe(0);
+    });
+
+    it('clearToasts will clear toasts from specified container if toastContainerId is number', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
+        toasterContainer.ngOnInit();
+
+        var toast: Toast = { type: 'info', toastContainerId: 1 };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        toasterService.clear(null, 1);
+        expect(toasterContainer.toasts.length).toBe(0);
+    });
+
+    it('clearToasts will not clear toasts from specified container if toastContainerId does not match', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
+        toasterContainer.ngOnInit();
+
+        var toast: Toast = { type: 'info', toastContainerId: 1 };
+        toasterService.pop(toast);
+
+        expect(toasterContainer.toasts.length).toBe(1);
+
+        toasterService.clear(null, 2);
+        expect(toasterContainer.toasts.length).toBe(1);
+    });
+
+    it('createGuid should create unique Guids', () => {
+        toasterContainer.toasterconfig = new ToasterConfig({ toastContainerId: 1 });
+        toasterContainer.ngOnInit();
+
+        var toastIds = [];
+
+        for (var i = 0; i < 10000; i++) {
+            var toast = toasterService.pop('success', 'toast');
+            toastIds.push(toast.toastId);
+            toasterService.clear();
+        }
+
+        var valuesSoFar = Object.create(null);
+        var dupFound = false;
+        for (var i = 0; i < toastIds.length; ++i) {
+            var value = toastIds[i];
+            if (value in valuesSoFar) {
+                dupFound = true;
+                break;
+            }
+            valuesSoFar[value] = true;
+        }
+
+        expect(dupFound).toBe(false);
+
+        toastIds = null;
+        valuesSoFar = null;
+    });
+});
+
+
+describe('ToasterContainerComponent when included as a component', () => {
+    var changeDetectorRef: ChangeDetectorRef,
+        testComponentBuilder: TestComponentBuilder,
+        componentResolver: ComponentResolver;
+
+    let fixture;
+
+    beforeEach(injectAsync([TestComponentBuilder, ComponentResolver], (tcb, compRes) => {
+        return tcb
+            //.overrideProviders(TestComponent, appRef)
+            .createAsync(TestComponent)
+            .then((f: ComponentFixture<TestComponent>) => {
+                fixture = f;
+            })
+            .catch(e => {
+                expect(e).toBeUndefined();
+            });
+    }));
+
+    it('should use the bound toasterconfig object if provided', () => {
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance).toBeDefined();
+
+        var container = fixture.debugElement.children[0].componentInstance;
+
+        expect(container).toBeDefined();
+        expect(container.toasterconfig).toBeDefined();
+        expect(container.toasterconfig.showCloseButton).toBe(true);
+        expect(container.toasterconfig.tapToDismiss).toBe(false);
+        expect(container.toasterconfig.timeout).toBe(0);
+    });
+
+    it('should invoke the click event when a toast is clicked but not remove toast if !tapToDismiss', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+        expect(container.toasterconfig.tapToDismiss).toBe(false);
+
+        fixture.componentInstance.toasterService.pop('success', 'test', 'test');
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toast = fixture.nativeElement.querySelector('div.toast');
+
+        toast.click();
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+    });
+
+    it('should invoke the click event when a toast is clicked and remove toast if tapToDismiss', () => {
+        fixture.componentInstance.toasterconfig.tapToDismiss = true;
+        fixture.detectChanges();
+        expect(fixture.componentInstance).toBeDefined();
+        var container = fixture.debugElement.children[0].componentInstance;
+
+        expect(container.toasterconfig.tapToDismiss).toBe(true);
+
+        fixture.componentInstance.toasterService.pop('success', 'test', 'test');
+
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toast = fixture.nativeElement.querySelector('div.toast');
+
+        toast.click();
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(0);
+    });
+
+    it('should invoke the click event when the close button is clicked even if !tapToDismiss', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+
+        expect(container.toasterconfig.tapToDismiss).toBe(false);
+
+        fixture.componentInstance.toasterService.pop('success', 'test', 'test');
+
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
+
+        toastButton.click();
+        fixture.detectChanges();
+            
+        setTimeout(() => {
+            expect(container.toasts.length).toBe(0);
+        }, 0);
+    });
+
+    it('should remove toast if clickHandler evaluates to true', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+        var toast: Toast = {
+            type: 'success', clickHandler: (toast, isCloseButton) => { return true; }
+        };
+
+        fixture.componentInstance.toasterService.pop(toast);
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
+
+        toastButton.click();
+        fixture.detectChanges();
+        
+        setTimeout(() => {
+            expect(container.toasts.length).toBe(0);
+        }, 0);
+    });
+
+    it('should not remove toast if clickHandler evaluates to false', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+        var toast: Toast = {
+            type: 'success', clickHandler: (toast, isCloseButton) => { return false; }
+        };
+
+        fixture.componentInstance.toasterService.pop(toast);
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
+
+        toastButton.click();
+        fixture.detectChanges();
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+    });
+
+    it('should log error if clickHandler is not a function and not remove toast', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+        var toast = { type: 'success', clickHandler: {} };
+
+        fixture.componentInstance.toasterService.pop(toast);
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        var toastButton = fixture.nativeElement.querySelector('.toast-close-button');
+        var x = toastButton.click()
+
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+    });
+
+    it('addToast should render component if it exists', () => {
+        fixture.detectChanges();
+        var container = fixture.debugElement.children[0].componentInstance;
+        var toast: Toast = {
+            type: 'success',
+            title: 'Yay',
+            body: TestDynamicComponent,
+            bodyOutputType: BodyOutputType.Component
+        }
+
+        fixture.componentInstance.toasterService.pop(toast);
+        fixture.detectChanges();
+        expect(container.toasts.length).toBe(1);
+
+        setTimeout(() => {
+            var renderedToast = fixture.nativeElement.querySelector('test-dynamic-component');
+            expect(renderedToast.innerHTML).toBe('<div>loaded via component</div>'); 
+        }, 1);
+    });
+});
+
+describe('Multiple ToasterContainerComponent components', () => {
+    var changeDetectorRef: ChangeDetectorRef,
+        testComponentBuilder: TestComponentBuilder;
+
+    let fixture;
+
+    beforeEach(injectAsync([TestComponentBuilder], tcb => {
+        return tcb
+            .overrideTemplate(TestComponent,
+            `<toaster-container [toasterconfig]="toasterconfig"></toaster-container>
                      <toaster-container [toasterconfig]="toasterconfig2"></toaster-container>`)
-                .createAsync(TestComponent)
-                .then(f => fixture = f)
-                .catch(e => expect(e).toBeUndefined());
-        }));
+            .createAsync(TestComponent)
+            .then(f => fixture = f)
+            .catch(e => expect(e).toBeUndefined());
+    }));
 
-        it('should create multiple container instances', () => {
-            fixture.componentInstance.toasterconfig.toastContainerId = 1;
-            fixture.componentInstance.toasterconfig2.toastContainerId = 2;
-            fixture.detectChanges();
+    it('should create multiple container instances', () => {
+        fixture.componentInstance.toasterconfig.toastContainerId = 1;
+        fixture.componentInstance.toasterconfig2.toastContainerId = 2;
+        fixture.detectChanges();
 
-            expect(fixture).toBeDefined();
-            expect(fixture.componentInstance.toasterconfig).toBeDefined();
-            expect(fixture.componentInstance.toasterconfig2).toBeDefined();
-        });
-
-        it('should only receive toasts targeted for that container', () => {
-            fixture.componentInstance.toasterconfig.toastContainerId = 1;
-            fixture.componentInstance.toasterconfig2.toastContainerId = 2;
-            fixture.detectChanges();
-
-            var toast1: Toast = {
-                type: 'success',
-                title: 'fixture 1',
-                toastContainerId: 1
-            };
-
-            var toast2: Toast = {
-                type: 'success',
-                title: 'fixture 2',
-                toastContainerId: 2
-            };
-
-            fixture.componentInstance.toasterService.pop(toast1);
-            fixture.componentInstance.toasterService.pop(toast2);
-
-            fixture.detectChanges();
-
-            let container1 = fixture.debugElement.children[0].componentInstance;
-            let container2 = fixture.debugElement.children[1].componentInstance;
-
-            expect(container1.toasts.length).toBe(1);
-            expect(container2.toasts.length).toBe(1);
-            expect(container1.toasts[0].title).toBe('fixture 1');
-            expect(container2.toasts[0].title).toBe('fixture 2');
-        });
+        expect(fixture).toBeDefined();
+        expect(fixture.componentInstance.toasterconfig).toBeDefined();
+        expect(fixture.componentInstance.toasterconfig2).toBeDefined();
     });
-}
+
+    it('should only receive toasts targeted for that container', () => {
+        fixture.componentInstance.toasterconfig.toastContainerId = 1;
+        fixture.componentInstance.toasterconfig2.toastContainerId = 2;
+        fixture.detectChanges();
+
+        var toast1: Toast = {
+            type: 'success',
+            title: 'fixture 1',
+            toastContainerId: 1
+        };
+
+        var toast2: Toast = {
+            type: 'success',
+            title: 'fixture 2',
+            toastContainerId: 2
+        };
+
+        fixture.componentInstance.toasterService.pop(toast1);
+        fixture.componentInstance.toasterService.pop(toast2);
+
+        fixture.detectChanges();
+
+        let container1 = fixture.debugElement.children[0].componentInstance;
+        let container2 = fixture.debugElement.children[1].componentInstance;
+
+        expect(container1.toasts.length).toBe(1);
+        expect(container2.toasts.length).toBe(1);
+        expect(container1.toasts[0].title).toBe('fixture 1');
+        expect(container2.toasts[0].title).toBe('fixture 2');
+    });
+});

--- a/src/toaster.service.ts
+++ b/src/toaster.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from 'angular2/core';
+import {Injectable} from '@angular/core';
 import {Toast} from './toast';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/share';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,6 +15,7 @@
       "bodyOutputType.ts",
       "toast.ts",
       "toaster-config.ts",
+      "toast.component.ts",
       "toaster-container.component.ts",
       "toaster-container.component.spec.ts",
       "toaster.service.ts",


### PR DESCRIPTION
BodyOutputType.Component (the ability to render components as the body
of the toast) has been updated to remove the soon to be deprecated
DynamicComponentLoader in favor of the ComponentResolver.

Toast rendering has been moved to its own component.

ToasterContainerComponent.Template The template has been updated to the
new *ngFor syntax.

Closes [#14](https://github.com/Stabzs/Angular2-Toaster/issues/14).