### PR TITLE
add missing html attribute to interface description of toast

### DIFF
--- a/src/toast.ts
+++ b/src/toast.ts
@@ -11,6 +11,7 @@ export interface Toast {
     onShowCallback?: OnActionCallback;
     onHideCallback?: OnActionCallback;
     data?: Object;
+    html?: string;
     
     timeout?: number;
     timeoutId?: number;


### PR DESCRIPTION
the html attribute is used within toast.component.ts L15, but never declared and results within an compile error when using the TrustedHtml option with a typed Toast-Object