### PR TITLE
Added removeToast observable. 

### DIFF
--- a/src/toaster-container.component.spec.ts
+++ b/src/toaster-container.component.spec.ts
@@ -548,6 +548,21 @@ describe('ToasterContainerComponent with sync ToasterService', () => {
         expect(status).toBe('updated');
     });
 
+    it('removeToast notifies the removeToast subscribers', (done) => {
+        toasterContainer.ngOnInit();
+
+        var toast: Toast = { type: 'info', title: 'default' };
+        toasterService.pop(toast);
+
+        toasterService.removeToast.subscribe(t => {
+            expect(t.toastId).toEqual(toast.toastId);
+            expect(t.toastContainerId).toEqual(toast.toastContainerId);
+            done();
+        });
+        
+        toasterService.clear(toast.toastId);
+    });
+
     it('clearToasts will clear toasts from all containers if toastContainerId is undefined', () => {
         toasterContainer.ngOnInit();
 

--- a/src/toaster-container.component.ts
+++ b/src/toaster-container.component.ts
@@ -173,6 +173,7 @@ export class ToasterContainerComponent {
             toast.timeoutId = null;
         }
         if (toast.onHideCallback) toast.onHideCallback(toast);
+        this.toasterService._removeToastSubject.next({ toastId: toast.toastId, toastContainerId: toast.toastContainerId });
     }
 
     private removeAllToasts() {

--- a/src/toaster.service.ts
+++ b/src/toaster.service.ts
@@ -3,6 +3,7 @@ import {Toast} from './toast';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/share';
 import {Observer} from 'rxjs/Observer';
+import {Subject} from 'rxjs/Subject';
 
 
 @Injectable()
@@ -13,13 +14,18 @@ export class ToasterService {
     clearToasts: Observable<IClearWrapper>;
     private _clearToasts: Observer<IClearWrapper>;
 
-    
+    removeToast: Observable<IClearWrapper>;
+    /** @internal */
+    _removeToastSubject: Subject<IClearWrapper>
+
     /**
      * Creates an instance of ToasterService.
      */
     constructor() {
         this.addToast = new Observable<Toast>(observer => this._addToast = observer).share();
         this.clearToasts = new Observable<IClearWrapper>(observer => this._clearToasts = observer).share();
+        this._removeToastSubject = new Subject<IClearWrapper>()
+        this.removeToast = this._removeToastSubject.share();
     }
 
     

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,7 +9,8 @@
     "removeComments": false,
     "noImplicitAny": false,
     "declaration": true,
-    "outDir": "../lib"
+    "outDir": "../lib",
+    "stripInternal": true
   },
   "files": [
       "bodyOutputType.ts",


### PR DESCRIPTION
At last I've found some time to implement this feature.
This implements #42 

To avoid exposing the public `_removeToastSubject` in the `ToasterService` I've added the flag `stripInternal` in the tsconfig. If you prefer another solution let me know and I'll change the commit.