### PR TITLE
Allow angular 5.x peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "url": "https://github.com/stabzs/Angular2-Toaster/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/core": "^4.0.0",
+    "@angular/common": "^4.0.0 || ^5.0.0",
+    "@angular/compiler": "^4.0.0 || ^5.0.0",
+    "@angular/core": "^4.0.0 || ^5.0.0",
     "rxjs": "^5.0.0-beta.11"
   },
   "devDependencies": {


### PR DESCRIPTION
This is already working in 5.x, there's just the `npm install` warning.  Expanding the peer dependencies would remove that error.

Not a breaking change.