### PR TITLE
feat(Allow for ToastId parameter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 5.1.0 (2018-05-19)
+### FEATURES
+* **toaster.service:** If a toastId is provided, that toastId is used instead of auto-generating 
+a toastId.  Thanks to @sherlock1982 for his work on 
+[#158](https://github.com/Stabzs/Angular2-Toaster/pull/158).
+
+### BUG FIXES
+* **toaster-container.component:** Mouseover functionality would incorrectly remove a toast when
+the toast's timeout was set to 0 and the container's configuration was set to a value other than 
+0.  Closes [#164](https://github.com/Stabzs/Angular2-Toaster/issues/164).
+
+
 # 5.0.1 (2018-03-16)
 ### BUG FIXES
 * **toaster-container.component:** Typescript compilation was failing for implicit any conversions 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 **angular2-toaster** is an asynchronous, non-blocking, Ahead of Time Compilation-supported Angular Toaster Notification library 
 largely based off of [AngularJS-Toaster](https://github.com/jirikavi/AngularJS-Toaster).
 
-[![npm](https://img.shields.io/npm/v/angular2-toaster.svg?maxAge=3600?cache=true)](https://www.npmjs.com/package/angular2-toaster)
-[![npm](https://img.shields.io/npm/dt/angular2-toaster.svg?cache=true)](https://www.npmjs.com/package/angular2-toaster)
+[![npm](https://img.shields.io/npm/v/angular2-toaster.svg?maxAge=3600?cached=true)](https://www.npmjs.com/package/angular2-toaster)
+[![npm](https://img.shields.io/npm/dt/angular2-toaster.svg?cached=true)](https://www.npmjs.com/package/angular2-toaster)
 [![Build Status](https://travis-ci.org/Stabzs/Angular2-Toaster.svg?branch=master)](https://travis-ci.org/Stabzs/Angular2-Toaster)
-[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&b=5.0.1)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&b=5.1.0)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
 
 
-Version ^ 5.0.0 requires either `.forRoot()` or `.forChild()` `ToasterModule` inclusion.  Please 
-read the 5.x.x release notes the `Getting Started` section before upgraded.
+Version ^5.0.0 requires either `.forRoot()` or `.forChild()` `ToasterModule` inclusion.  Please 
+read the 5.x.x release notes and the `Getting Started` section before upgraded.
 
 Version ^4.0.0 now supports @angular/animations, which is a breaking change. 
 Please read both the Getting Started and Animations sections before upgrading.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-toaster",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "An Angular Toaster Notification library based on AngularJS-Toaster",
   "main": "bundles/angular2-toaster.umd.js",
   "module": "angular2-toaster.js",

--- a/src/toaster-container.component.ts
+++ b/src/toaster-container.component.ts
@@ -146,7 +146,7 @@ export class ToasterContainerComponent implements OnInit, OnDestroy {
             if (!timeoutId) {
                 this.configureTimer(toast);
             }
-        } else if (!timeoutId && this.toasterconfig.timeout) {
+        } else if (toast.timeout !== 0 && !timeoutId && this.toasterconfig.timeout) {
             this.removeToast(toast);
         }
     }


### PR DESCRIPTION
Mouseover functionality would incorrectly remove a toast when the toast's timeout was set to 0 and the container's configuration was set to a value other than 0.  Closes #164.