### PR TITLE
Added bypassSecurityTrustHtml for toast.body to allow svgs elements

### DIFF
--- a/src/toast.component.ts
+++ b/src/toast.component.ts
@@ -13,7 +13,7 @@ import {BodyOutputType} from './bodyOutputType';
             <div [ngClass]="titleClass">{{toast.title}}</div>
             <div [ngClass]="messageClass" [ngSwitch]="toast.bodyOutputType">
                 <div *ngSwitchCase="bodyOutputType.Component" #componentBody></div>
-                <div *ngSwitchCase="bodyOutputType.TrustedHtml" [innerHTML]="toast.body"></div>
+                <div *ngSwitchCase="bodyOutputType.TrustedHtml" [innerHTML]="safeBodyHtml"></div>
                 <div *ngSwitchCase="bodyOutputType.Default">{{toast.body}}</div>
             </div>
         </div>
@@ -31,6 +31,7 @@ export class ToastComponent implements OnInit, AfterViewInit {
     @ViewChild('componentBody', { read: ViewContainerRef }) componentBody: ViewContainerRef;
 
     safeCloseHtml: SafeHtml;
+    safeBodyHtml: SafeHtml;
 
     public bodyOutputType = BodyOutputType;
 
@@ -46,6 +47,9 @@ export class ToastComponent implements OnInit, AfterViewInit {
     ngOnInit() {
         if (this.toast.closeHtml) {
             this.safeCloseHtml = this.sanitizer.bypassSecurityTrustHtml(this.toast.closeHtml);
+        }
+        if (this.toast.bodyOutputType === BodyOutputType.TrustedHtml) {
+            this.safeBodyHtml = this.sanitizer.bypassSecurityTrustHtml(this.toast.body);
         }
     }
 

--- a/src/toaster-container.component.spec.ts
+++ b/src/toaster-container.component.spec.ts
@@ -508,6 +508,25 @@ describe('ToasterContainerComponent with sync ToasterService', () => {
         expect(toasterContainer.toasts[0]).toBe(toast4);
     });
 
+    it('addToast will not populate body with TrustedHtml if body is null', () => {
+        toasterContainer.toasterconfig = new ToasterConfig();
+        toasterContainer.ngOnInit();
+        const testSvg = '<svg width="400" height="110"><rect width="300" height="100" style="fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"></rect></svg>';
+
+        const toast1: Toast = { 
+            type: 'info',
+            title: '1',
+            body: testSvg,
+            bodyOutputType: BodyOutputType.TrustedHtml 
+        };
+
+        toasterService.pop(toast1);
+        fixture.detectChanges();
+
+        const closeButtonEle = fixture.nativeElement.querySelector('.toast-message');
+        expect(closeButtonEle.innerHTML).toContain(testSvg);
+    });
+
     it('addToast will not populate safeCloseHtml if closeHtml is null', () => {
         toasterContainer.toasterconfig = new ToasterConfig();
         toasterContainer.toasterconfig.closeHtml = null;


### PR DESCRIPTION
And others elements in the html body message.

Like it already been done for the closeHtml.
Plus added a test for it. 