### PR TITLE
feat(toast.body bypass trusted html)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
+# 6.1.0 (2018-06-21)
+### FEATURES
+* **toaster-container.component:** Added bypassSecurityTrustHtml support for the body parameter 
+for the `TrustedHtml` body output type.  Thanks to @TGNC for making the change.  
+
+### DOCUMENTATION
+* **readme:** Documented ErrorHandler cases.  Closes [#169](https://github.com/Stabzs/Angular2-Toaster/issues/169).
+
 # 6.0.0 (2018-05-19)
 ### FEATURES 
-* **angular2-toaster:** Full release of 6.0.0 functionality.  Pins the library to 6.0.0 versions of Angular and RxJS.
-Closes [#161](https://github.com/Stabzs/Angular2-Toaster/issues/161).
+* **angular2-toaster:** Full release of 6.0.0 functionality.  Pins the library to 6.0.0 versions 
+of Angular and RxJS. Closes [#161](https://github.com/Stabzs/Angular2-Toaster/issues/161).
 
 
 # 5.1.0 (2018-05-19)
@@ -12,8 +20,8 @@ a toastId.  Thanks to @sherlock1982 for his work on
 
 ### BUG FIXES
 * **toaster-container.component:** Mouseover functionality would incorrectly remove a toast when
-the toast's timeout was set to 0 and the container's configuration was set to a value other than 
-0.  Closes [#164](https://github.com/Stabzs/Angular2-Toaster/issues/164).
+the toast's timeout was set to 0 and the container's configuration was set to a value other than 0.  
+Closes [#164](https://github.com/Stabzs/Angular2-Toaster/issues/164).
 
 
 # 5.0.1 (2018-03-16)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ largely based off of [AngularJS-Toaster](https://github.com/jirikavi/AngularJS-T
 [![npm](https://img.shields.io/npm/v/angular2-toaster.svg?maxAge=3600?caching=true)](https://www.npmjs.com/package/angular2-toaster)
 [![npm](https://img.shields.io/npm/dt/angular2-toaster.svg?caching=true)](https://www.npmjs.com/package/angular2-toaster)
 [![Build Status](https://travis-ci.org/Stabzs/Angular2-Toaster.svg?branch=master)](https://travis-ci.org/Stabzs/Angular2-Toaster)
-[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&b=6.0.0)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Stabzs/Angular2-Toaster/badge.svg?branch=master&b=6.1.0)](https://coveralls.io/github/Stabzs/Angular2-Toaster?branch=master)
 
 
 Version ^5.0.0 requires either `.forRoot()` or `.forChild()` `ToasterModule` inclusion.  Please 
@@ -560,6 +560,32 @@ Run Karma test instance with coverage report:
 npm run test
 ```
 
+# Frequently Asked Questions and Issues
+## I get the `No Toaster Containers have been initialized to receive toasts.` error
+
+You have not properly initialized a toaster container instance before trying to publish a toast. 
+Make sure that you have rendered the `toaster-container` component and that you are importing 
+the `ToasterModule` with `ToasterModule.forRoot()`.
+
+## Toasts are not displayed when popped from an error handler
+The `handleError` function is executed outsize of an Angular zone.  You need to 
+explicitly tell Angular to run the pop call within the context of a zone.
+
+```TypeScript
+export class AppErrorHandler implements ErrorHandler {
+    constructor(
+        private toasterService: ToasterService,
+        private ngZone : NgZone) { }
+
+    handleError(error: any): void {
+        this.ngZone.run(() => {
+            this.toasterService.pop('error', "Error", error);
+        });  
+    }
+}
+```
+(See this great [Stack Overflow Answer]( https://stackoverflow.com/questions/44975477/angular2-ng-toasty-errorhandler) for more details).
+
 
 ## Author
 [Stabzs](stabzssoftware@gmail.com)
@@ -570,7 +596,7 @@ Rewritten from https://github.com/jirikavi/AngularJS-Toaster
 Inspired by http://codeseven.github.io/toastr/demo.html.
 
 ## Copyright
-Copyright © 2016-2017 Stabzs.
+Copyright © 2016-2018 Stabzs.
 
 
 ## Licence

--- a/demo/angular-cli/src/app/routes/home/home/home.component.html
+++ b/demo/angular-cli/src/app/routes/home/home/home.component.html
@@ -4,6 +4,7 @@
   <h1>
     Welcome to {{ title }}!
     <button (click)="popToast()">pop toast</button>
+    <button (click)="toto()">pop toto toast</button>
   </h1>
   <img width="300" alt="Angular Logo" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg==">
 </div>

--- a/demo/angular-cli/src/app/routes/home/home/home.component.ts
+++ b/demo/angular-cli/src/app/routes/home/home/home.component.ts
@@ -1,18 +1,20 @@
-import { Component } from '@angular/core';
-import { ToasterService, IToasterConfig, ToasterConfig } from '@angular2-toaster/angular2-toaster';
+import { Component, AfterViewInit } from '@angular/core';
+import { ToasterService, IToasterConfig, ToasterConfig, Toast } from '@angular2-toaster/angular2-toaster';
 
 @Component({
   selector: 'app-root',
   templateUrl: './home.component.html',
 })
-export class HomeComponent {
+export class HomeComponent implements AfterViewInit {
   title = 'home';
 
   constructor(public toasterService: ToasterService) {}
 
   homeConfig: IToasterConfig = new ToasterConfig({
-    animation: 'fade', newestOnTop: false, 
-    positionClass: 'toast-bottom-center', toastContainerId: 4
+    animation: 'fade', 
+    newestOnTop: false, 
+    positionClass: 'toast-bottom-center', 
+    toastContainerId: 4
   });
 
   popToast() {
@@ -23,5 +25,23 @@ export class HomeComponent {
     });
 
     window.setTimeout(() => toast.title = 'Updated Home Title', 1000)
+  }
+
+  ngAfterViewInit() {
+    console.log('entering view init');
+    const toast: Toast = {
+      type: 'success',
+      body: 'I am init toast'
+    };
+    this.toasterService.pop(toast);
+  }
+
+  toto() {
+    console.log('toto button clicked');
+    const toast: Toast = {
+      type: 'success',
+      body: 'I am toto toast'
+    };
+    this.toasterService.pop(toast);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-toaster",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "An Angular Toaster Notification library based on AngularJS-Toaster",
   "main": "bundles/angular2-toaster.umd.js",
   "module": "angular2-toaster.js",


### PR DESCRIPTION
Added bypassSecurityTrustHtml support for the body parameter for the `TrustedHtml` body output type.  Thanks to @TGNC for making the change.

Documented ErrorHandler cases.  Closes https://github.com/Stabzs/Angular2-Toaster/issues/169.